### PR TITLE
Adapt pa2checker to ontology updates

### DIFF
--- a/frontend_pa_inference.py
+++ b/frontend_pa_inference.py
@@ -2,12 +2,12 @@ import shutil, os
 import pa2checker
 import common
 
-def run_pa2checker(annotations):
+def run_pa2checker(ontology_values):
   pa2checker.revert_checker_source()
 
-  for annotation, classes in annotations.iteritems():
-    pa2checker.create_type_annotation(annotation)
-    pa2checker.update_ontology_utils(annotation, classes)
+  for ontology_value, classes in ontology_values.iteritems():
+    pa2checker.insert_ontology_value(ontology_value)
+    pa2checker.update_ontology_utils(ontology_value, classes)
   pa2checker.recompile_checker_framework()
 
 def run_inference(project):
@@ -37,9 +37,9 @@ def run_inference(project):
 
 
 def run(project_list):
-  annotations = { "Sequence": ['java.util.List', 'java.util.LinkedHashSet'] }
+  ontology_values = { "Sequence": ['java.util.List', 'java.util.LinkedHashSet'] }
 
-  run_pa2checker(annotations)
+  run_pa2checker(ontology_values)
 
   for project in project_list:
     common.clean_project(project)

--- a/pa2checker/__init__.py
+++ b/pa2checker/__init__.py
@@ -1,6 +1,6 @@
 import pa2checker
 
-create_type_annotation = pa2checker.create_type_annotation
+insert_ontology_value = pa2checker.insert_ontology_value
 update_ontology_utils = pa2checker.update_ontology_utils
 recompile_checker_framework = pa2checker.recompile_checker_framework
 revert_checker_source = pa2checker.revert_checker_source

--- a/pa2checker/pa2checker.py
+++ b/pa2checker/pa2checker.py
@@ -13,27 +13,41 @@ def revert_checker_source():
     common.run_cmd(['git', 'clean', '-f', '.'])
     common.run_cmd(['git', 'checkout', '.'])
 
-def create_type_annotation(annotation_name, super_type_names=['OntologyTop']):
-  annotation_file_dir = os.path.join(SOLVER_SRC_DIR, 'qual')
-  annotation_file_name = os.path.join(annotation_file_dir, '{}.java'.format(annotation_name))
+def insert_ontology_value(value_name):
+  """ insert ontology value to the file
+  tools/ontology/src/ontology/qual/OntologyValue.java
+  which is the enum class manages all the ontology values, annotaion would be gnereated
+  in the form of @Ontology(values="{OntologyValue.ontology_value_name}")
+  """
+  ontology_qual_dir = os.path.join(SOLVER_SRC_DIR, 'qual')
+  ontology_value_file = os.path.join(ontology_qual_dir, 'OntologyValue.java')
 
-  print ("Writing annotation {} to file {}".format(annotation_name, annotation_file_name))
-  #first generate the definition of the annotation
-  with open(annotation_file_name, 'w') as out_file:
-    with open(os.path.join(WORKING_DIR, "annotation.java.prototype"), 'r') as proto_file:
+  capitial_value_name = value_name.upper()
+
+  insert_enum = "    {}(\"{}\"),\n".format(capitial_value_name, value_name.lower())
+  botttom_enum = "BOTTOM(\"BOTTOM\");"
+
+  with tempfile.NamedTemporaryFile(mode='w', suffix='.java') as out_file:
+    with open(ontology_value_file, 'r') as proto_file:
+
+      already_existed = False
+
       for line in proto_file.readlines():
-        if "$ANNOTATION_NAME$" in line:
-          line = line.replace("$ANNOTATION_NAME$", annotation_name)
-        if "$SUPERTYPE_NAMES$" in line:
-          snames = []
-          for super_type_name in super_type_names:
-            snames+=["{}.class".format(super_type_name)]
-          line = line.replace("$SUPERTYPE_NAMES$", ','.join(snames))
+        if insert_enum in line:
+          already_existed = True;
+
+        if botttom_enum in line:
+          if not already_existed:
+            out_file.write(insert_enum)
+
         out_file.write(line)
 
-def update_ontology_utils(annotation_name, java_type_names):
+      out_file.flush()
+      shutil.copyfile(out_file.name, ontology_value_file)
+
+def update_ontology_utils(value_name, java_type_names):
   """ updates the file
-  tools/generic-type-inference-solver/src/ontology/util/OntologyUtils.java
+  tools/ontology/src/ontology/util/OntologyUtils.java
   which decides which java types get annotated with which annotation.
   """
 
@@ -43,26 +57,14 @@ def update_ontology_utils(annotation_name, java_type_names):
 
   ontology_util_dir = os.path.join(SOLVER_SRC_DIR, 'util')
   ontology_util_file = os.path.join(ontology_util_dir, 'OntologyUtils.java')
-  qualified_annotation_name = 'ontology.qual.{}'.format(annotation_name)
+  upper_value_name = value_name.upper()
 
   with tempfile.NamedTemporaryFile(mode='w', suffix='.java') as out_file:
     with open(ontology_util_file, 'r') as proto_file:
-      reading_imports = False
-      already_imported = False
       for line in proto_file.readlines():
-        if line.startswith("import "):
-          reading_imports = True
-          if qualified_annotation_name in line:
-            already_imported = True
+        out_file.write(line)
 
-        if reading_imports==True:
-          if not line.startswith("import ") and len(line.strip())>0:
-            reading_imports = False
-            if already_imported==False:
-              # Import the type annotation that we want to use.
-              out_file.write("import {};\n".format(qualified_annotation_name))
-
-        if "return null;" in line:
+        if "public static OntologyValue determineOntologyValue(TypeMirror type) {" in line:
           # This is where we add the new mapping
           out_file.write("        if (")
           conds = []
@@ -74,27 +76,36 @@ def update_ontology_utils(annotation_name, java_type_names):
               conds+=["TypesUtils.isDeclaredOfName(type, \"{}\")".format(java_type)]
           out_file.write(" || ".join(conds))
           out_file.write("){\n")
-          out_file.write("            AnnotationMirror SEQ = AnnotationUtils.fromClass(elements, {}.class);\n".format(annotation_name))
-          out_file.write("            return SEQ;\n")
+          out_file.write("            return OntologyValue.{};\n".format(upper_value_name))
           out_file.write("         }\n")
 
-        out_file.write(line)
         out_file.flush()
         shutil.copyfile(out_file.name, ontology_util_file)
 
 def recompile_checker_framework():
+  """ recompile checker framework stuffs
+      include:
+      - checker-framework-inference
+      - ontology
+  """
   if not os.environ.get('JAVA_HOME'):
-    print "ERROR in pa2checker.recompile_checker_framework(): Gradle will fail if your JAVA_HOME environment variable is unset. Please set it and try again."
+    print "ERROR in pa2checker.recompile_checker_framework_inference(): Gradle will fail if your JAVA_HOME environment variable is unset. Please set it and try again."
     sys.exit(0)
-  type_infer_tool_dir = os.path.join(common.TOOLS_DIR, "checker-framework-inference")
-  with common.cd(type_infer_tool_dir):
+  checker_framework_inference_dir = os.path.join(common.TOOLS_DIR, "checker-framework-inference")
+  ontology_dir = os.path.join(common.TOOLS_DIR, "ontology")
+
+  with common.cd(checker_framework_inference_dir):
     common.setup_checker_framework_env()
     common.run_cmd(["gradle", "dist", "-i"], print_output=True)
+
+  with common.cd(ontology_dir):
+    common.setup_checker_framework_env()
+    common.run_cmd(["gradle", "build", "-i"], print_output=True)
 
 
 def main():
   annotation = "Disco"
-  create_type_annotation(annotation)
+  insert_ontology_value(annotation)
   update_ontology_utils(annotation, ["java.util.Collection", "java.util.LinkedList"])
   recompile_checker_framework()
 

--- a/pa2checker/pa2checker.py
+++ b/pa2checker/pa2checker.py
@@ -89,7 +89,7 @@ def recompile_checker_framework():
       - ontology
   """
   if not os.environ.get('JAVA_HOME'):
-    print "ERROR in pa2checker.recompile_checker_framework_inference(): Gradle will fail if your JAVA_HOME environment variable is unset. Please set it and try again."
+    print "ERROR in pa2checker.recompile_checker_framework(): Gradle will fail if your JAVA_HOME environment variable is unset. Please set it and try again."
     sys.exit(0)
   checker_framework_inference_dir = os.path.join(common.TOOLS_DIR, "checker-framework-inference")
   ontology_dir = os.path.join(common.TOOLS_DIR, "ontology")


### PR DESCRIPTION
It seems we using `pa2checker` to insert ontology annotations and type rules into Ontology System.

However, the way of doing that is out-date as we have a huge refactor on the Ontology qualifier hierarchy recently. as a result, currently `pa2checker` would insert mismatched code which would failed the compilation of Ontology System after insertion.

I made some changes in `pa2checker` to adapt to the changes in Ontology.

Change summary:

- instead of creating annotation class for a annotation, insert an enum value in `OntologyValue.class`
(adapt to the change of using single annotation `@Ontology` to represent ontologies, which the ontologies are represented as values in the field `values` in `@Ontology` like this: `@Ontology(values="{OntologyValue.xxx}")` )

- remove import updates in `update_ontology_util` as we don't need that anymore

- tiny modification of  the content of  inserted return statement in `update_ontology_util`

- add re-compilation of `Ontology` system in `recompile_checker_framework` as currently we separate `ontology` from `checker-framework-inference` and thus we need add an extra step to get `ontology` also be re-compiled after inserting changes.

 - tiny changes in `frontend_pa_inference.py` to adapt to changes in `pa2checker`

I've tested it in my local machine and it seems works fine to me.