### PR TITLE
Update Randoop version to 3.0.7

### DIFF
--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -9,7 +9,7 @@ pushd libs &> /dev/null
 
 JARS=(
     "http://plse.cs.washington.edu/daikon/download/daikon.jar"
-    "https://github.com/randoop/randoop/releases/download/v3.0.6/randoop-all-3.0.6.jar"
+    "https://github.com/randoop/randoop/releases/download/v3.0.7/randoop-all-3.0.7.jar"
     "https://github.com/aas-integration/prog2dfg/releases/download/v0.1/prog2dfg.jar"
     "https://github.com/junit-team/junit/releases/download/r4.12/junit-4.12.jar"
     "http://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"


### PR DESCRIPTION
Modifies `fetch_dependencies.sh` to use URL for Randoop release version 3.0.7:
[randoop-all-3.0.7.jar](https://github.com/randoop/randoop/releases/download/v3.0.7/randoop-all-3.0.7.jar)