### PR TITLE
Remove hardcoded dot paths

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,5 +1,6 @@
 import os, sys
 import common
+import dot
 import argparse
 
 def generate_graphs(project):
@@ -29,8 +30,8 @@ def gather_kernels(projects, corpus_kernel_file):
   with open(corpus_kernel_file, "w") as corpus_kernel_file_handle:
     for project in projects:
       project_dir = common.get_project_dir(project)
-      out_dir = common.DOT_DIR[project]
-      project_kernel_file_path = common.get_kernel_path(project, out_dir)
+      out_dir = dot.dot_dirs(project)[0]
+      project_kernel_file_path = dot.get_kernel_path(project, out_dir)
       
       if os.path.isfile(project_kernel_file_path):
         with open(project_kernel_file_path, "r") as fi: 
@@ -47,11 +48,9 @@ def generate_project_kernel(project, cluster_json=None):
   
   project_dir = common.get_project_dir(project)
 
-  if not (project in common.DOT_DIR):
-    common.DOT_DIR[project] = "_classes"
-  out_dir = common.DOT_DIR[project]
+  out_dir = dot.dot_dirs(project)[0]
   
-  kernel_file_path = common.get_kernel_path(project, out_dir)
+  kernel_file_path = dot.get_kernel_path(project, out_dir)
   
   if cluster_json:
     print("Using clustering output for node relabeling:")

--- a/backend2.py
+++ b/backend2.py
@@ -1,5 +1,6 @@
 import os, sys
 import common
+import dot
 import argparse
 from simprog import Similarity
 
@@ -22,8 +23,8 @@ def generate_project_kernel(project, cluster_json=None):
   """ run graph kernel computation """
   
   project_dir = common.get_project_dir(project)
-  out_dir = common.DOT_DIR[project]
-  kernel_file_path = common.get_kernel_path(project, out_dir)
+  out_dir = dot.dot_dirs(project)[0]
+  kernel_file_path = dot.get_kernel_path(project, out_dir)
   
   if cluster_json:
     print("Using clustering output for node relabeling:")
@@ -52,8 +53,8 @@ def compute_all_pairs_similarity(result_dir):
   for (yl,project) in enumerate(common.LIMITED_PROJECT_LIST):
     ind_file = os.path.join(result_dir, project+".txt")
     project_dir = common.get_project_dir(project)
-    out_dir = common.DOT_DIR[project]
-    project_kernel_file_path = common.get_kernel_path(project, out_dir)
+    out_dir = dot.dot_dirs(project)[0]
+    project_kernel_file_path = dot.get_kernel_path(project, out_dir)
     prog_count = sim.read_graph_kernels(project_kernel_file_path, yl)
     with open(ind_file, "w") as indf: 
         for i in range(counter, counter+prog_count):          

--- a/common.py
+++ b/common.py
@@ -8,36 +8,15 @@ LIBS_DIR = os.path.join(WORKING_DIR, "libs")
 CORPUS_DIR = os.path.join(WORKING_DIR, "corpus")
 CORPUS_INFO = None
 TOOLS_DIR = os.path.join(WORKING_DIR, "tools")
+SIMPROG_DIR = os.path.join(WORKING_DIR, "simprog")
 
 CLUSTER_FILE = os.path.join(WORKING_DIR, "clusters.json")
-
 CLASS2FIELDS_FILE = os.path.join(WORKING_DIR, "c2f.json")
 
 DLJC_BINARY = os.path.join(TOOLS_DIR, "do-like-javac", "dljc")
 DLJC_OUTPUT_DIR = "dljc-out"
 
 LIMITED_PROJECT_LIST = ["dyn4j", "jreactphysics3d", "jbox2d", "react", "jmonkeyengine"]
-
-DOT_DIR = {}
-DOT_DIR["jreactphysics3d"] = "_target_classes"
-DOT_DIR["dyn4j"] = "_bin"
-DOT_DIR["react"] = "_build_classes_main"
-DOT_DIR["jmonkeyengine"] = "_jme3-core_build_classes_main"
-DOT_DIR["jbox2d"] = "_jbox2d-testbed_target_classes"
-
-ALL_DOT_DIR = {}
-ALL_DOT_DIR["jreactphysics3d"] = ["_target_classes"]
-ALL_DOT_DIR["dyn4j"] = ["_bin", "_output_examples", "_output_junit", "_output_sandbox"]
-ALL_DOT_DIR["react"] = ["_build_classes_main"]
-ALL_DOT_DIR["jmonkeyengine"] = ["_jme3-jogg_build_classes_main", "_jme3-android_build_classes_main", \
-"_jme3-jogl_build_classes_main", "_jme3-blender_build_classes_main", "_jme3-lwjgl3_build_classes_main", \
-"_jme3-bullet_build_classes_main",  "_jme3-lwjgl_build_classes_main", "_jme3-core_build_classes_main", \
-"_jme3-networking_build_classes_main", "_jme3-desktop_build_classes_main", "_jme3-niftygui_build_classes_main", \
-"_jme3-effects_build_classes_main", "_jme3-plugins_build_classes_main", "_jme3-ios_build_classes_main", \
-"_jme3-terrain_build_classes_main", "_jme3-jbullet_build_classes_main"]
-ALL_DOT_DIR["jbox2d"] = ["_jbox2d-serialization_target_classes", "_jbox2d-library_target_classes", "_jbox2d-testbed_target_classes"]
-
-SIMPROG_DIR = os.path.join(WORKING_DIR, "simprog")
 
 def run_cmd(cmd, print_output=False, timeout=None):
   def kill_proc(proc, stats):
@@ -91,61 +70,12 @@ def get_method_from_daikon_out(daikon_out):
   method = arr2[0]
   return method
 
-def find_dot_name(method_name, method_file):
-  with open(method_file, "r") as fi:
-    for line in fi:
-      line = line.rstrip()
-      arr = line.split('\t')
-      method_sig = arr[0]
-      dot_name = arr[1]
-      if method_name in method_sig:
-        return dot_name
-  return None
-
-def get_dot_path(project_name, output_dir, dot_name):
-  return os.path.join(get_project_dir(project_name), DLJC_OUTPUT_DIR, output_dir, dot_name)
-
 def get_jar(jar_name):
   path = os.path.join(LIBS_DIR, jar_name)
   if os.path.isfile(path):
     return path
   else:
     return None
-
-def get_method_summary_from_dot_path(dot_path):
-  arr = dot_path.split(os.sep)
-  dot_name = arr[-1]
-  dot_dir = arr[:-1]
-  proj_dir = arr[:-3]
-  method_arr = dot_dir + ["methods.txt"]
-  method_file = os.path.join("/", *method_arr)
-  sourceline_arr = dot_dir + ["sourcelines.txt"]
-  sourceline_file = os.path.join("/", *sourceline_arr)
-  mf = open(method_file, "r")
-  sf = open(sourceline_file, "r")
-  dot_to_method_dict = {}
-  method_to_source_dict = {}
-  for line in mf:
-    line = line.rstrip()
-    arr = line.split('\t')
-    method_sig = arr[0]
-    dot = arr[1]
-    dot_to_method_dict[dot] = method_sig
-  mf.close()
-  for line in sf:
-    line = line.rstrip()
-    arr = line.split('\t')
-    method_sig = arr[0]
-    source_file_name = arr[1]
-    method_to_source_dict[method_sig] = source_file_name
-  sf.close()
-
-  method_sig = dot_to_method_dict[dot_name]
-  source_file = method_to_source_dict[method_sig]
-  source_path = os.path.join("/", *(proj_dir + ["src/main", source_file]))
-  new_method_sig = method_sig[1:-1]
-  sig_arr = new_method_sig.split(' ')
-  return source_path+"::"+sig_arr[2]+"::"+sig_arr[1]
 
 def get_corpus_info():
   global CORPUS_INFO
@@ -163,12 +93,6 @@ def get_project_dir(project_name):
   else:
     return os.path.join(CORPUS_DIR, project['name'])
 
-def get_kernel_path(project_name, output_dir):
-  return os.path.join(get_project_dir(project_name), DLJC_OUTPUT_DIR, output_dir, 'kernel.txt')
-
-def get_method_path(project_name, output_dir):
-  return os.path.join(get_project_dir(project_name), DLJC_OUTPUT_DIR, output_dir, 'methods.txt')
-
 def get_project_list():
   return get_corpus_info()['projects'].keys()
 
@@ -178,14 +102,12 @@ def project_info(project_name):
 def get_simprog(py_file):
   return os.path.join(SIMPROG_DIR, py_file)
 
-
 def get_dljc_dir_for_project(project):
   dtrace_path = os.path.join(CORPUS_DIR, project, DLJC_OUTPUT_DIR)
   if os.path.exists(dtrace_path):
     return dtrace_path
   else:
     return None
-
 
 def clean_project(project):
   project_dir = get_project_dir(project)
@@ -198,7 +120,7 @@ def get_class_dirs(project):
   classdirs = []
 
   dljc_output = os.path.join(get_project_dir(project),
-                             'dljc-out',
+                             DLJC_OUTPUT_DIR,
                              'javac.json')
 
   if not os.path.exists(dljc_output):
@@ -213,7 +135,6 @@ def get_class_dirs(project):
         classdirs.append(classdir)
 
   return classdirs
-
 
 def run_dljc(project, tools, options=[], timelimit=1800.0):
   project_dir = get_project_dir(project)

--- a/dot.py
+++ b/dot.py
@@ -1,0 +1,72 @@
+from common import DLJC_OUTPUT_DIR, get_project_dir
+import os
+
+def find_dot_name(method_name, method_file):
+  with open(method_file, "r") as fi:
+    for line in fi:
+      line = line.rstrip()
+      arr = line.split('\t')
+      method_sig = arr[0]
+      dot_name = arr[1]
+      if method_name in method_sig:
+        return dot_name
+  return None
+
+def dot_dir(project_name):
+  return os.path.join(get_project_dir(project_name),
+                      DLJC_OUTPUT_DIR,
+                      "dot")
+
+def dot_dirs(project_name):
+  dd = dot_dir(project_name)
+
+  if os.path.exists(dd):
+    return os.listdir(dd)
+  else:
+    return None
+
+def get_dot_path(project_name, output_dir, dot_name):
+  return os.path.join(dot_dir(project_name),
+                      output_dir,
+                      dot_name)
+
+def get_kernel_path(project_name, output_dir):
+  return os.path.join(dot_dir(project_name), output_dir, 'kernel.txt')
+
+def get_method_path(project_name, output_dir):
+  return os.path.join(dot_dir(project_name), output_dir, 'methods.txt')
+
+# def get_method_summary_from_dot_path(dot_path):
+#   arr = dot_path.split(os.sep)
+#   dot_name = arr[-1]
+#   dot_dir = arr[:-1]
+#   proj_dir = arr[:-3]
+#   method_arr = dot_dir + ["methods.txt"]
+#   method_file = os.path.join("/", *method_arr)
+#   sourceline_arr = dot_dir + ["sourcelines.txt"]
+#   sourceline_file = os.path.join("/", *sourceline_arr)
+#   mf = open(method_file, "r")
+#   sf = open(sourceline_file, "r")
+#   dot_to_method_dict = {}
+#   method_to_source_dict = {}
+#   for line in mf:
+#     line = line.rstrip()
+#     arr = line.split('\t')
+#     method_sig = arr[0]
+#     dot = arr[1]
+#     dot_to_method_dict[dot] = method_sig
+#   mf.close()
+#   for line in sf:
+#     line = line.rstrip()
+#     arr = line.split('\t')
+#     method_sig = arr[0]
+#     source_file_name = arr[1]
+#     method_to_source_dict[method_sig] = source_file_name
+#   sf.close()
+
+#   method_sig = dot_to_method_dict[dot_name]
+#   source_file = method_to_source_dict[method_sig]
+#   source_path = os.path.join("/", *(proj_dir + ["src/main", source_file]))
+#   new_method_sig = method_sig[1:-1]
+#   sig_arr = new_method_sig.split(' ')
+#   return source_path+"::"+sig_arr[2]+"::"+sig_arr[1]

--- a/dyntrace/dyn4j.junit-after
+++ b/dyntrace/dyn4j.junit-after
@@ -1,0 +1,1 @@
+    for (java.awt.Window w: java.awt.Window.getWindows()) {w.dispose();}

--- a/dyntrace/imagej.omit-list
+++ b/dyntrace/imagej.omit-list
@@ -1,0 +1,3 @@
+ij.gui
+ij.macro
+ij.process

--- a/dyntrace/imgscalr.junit-after
+++ b/dyntrace/imgscalr.junit-after
@@ -1,0 +1,1 @@
+    org.imgscalr.AsyncScalr.getService().shutdownNow();

--- a/dyntrace/jbox2d.omit-list
+++ b/dyntrace/jbox2d.omit-list
@@ -1,0 +1,1 @@
+org.jbox2d.dynamics.World

--- a/experiment.py
+++ b/experiment.py
@@ -23,6 +23,7 @@ def main():
   common.mkdir(kernel_dir)
 
   backend.run(project_list, args, kernel_dir)
+  print("\n********* END OF BACKEND **********\n")
   frontend.run(project_list, args, kernel_dir)
 
 if __name__ == '__main__':

--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -50,12 +50,12 @@ pushd tools &> /dev/null
 if [ ! -d do-like-javac ]; then
     git clone https://github.com/SRI-CSL/do-like-javac.git
     pushd do-like-javac &> /dev/null
-    git checkout split-dyntrace
+    git checkout dot-dirs
     popd &> /dev/null # Exit do-like-javac
 else
     pushd do-like-javac &> /dev/null
     git fetch
-    git checkout split-dyntrace
+    git checkout dot-dirs
     git pull
     popd &> /dev/null # Exit do-like-javac
 fi

--- a/frontend.py
+++ b/frontend.py
@@ -10,7 +10,7 @@ import common
 import dot
 import argparse
 from simprog import Similarity
-
+import json
 
 def get_daikon_patterns():
   ordering_operator = "<="
@@ -98,23 +98,29 @@ def check_similarity(project, result_file, kernel_file, cluster_json=None, top_k
       corpus_dot_to_method_map[method_dot_path] = method_name
 
   # check similarity
+  json_result = {}
   sim = Similarity()
   sim.read_graph_kernels(kernel_file)
   iter_num = 3 # number of iteration of the WL-Kernel method
-  with open(result_file, 'w') as fo:
+  with open(result_file, "w") as fo:
     for dot_file in corpus_dot_to_method_map.keys():
+      dot_method = corpus_dot_to_method_map[dot_file]
+      json_result[dot_method] = []
       result_program_list_with_score = sim.find_top_k_similar_graphs(dot_file, dot_file, top_k, iter_num, cluster_json)
       line = dot_file+":\n"
       for (dt, score) in result_program_list_with_score:
+        json_result[dot_method].append((dot_method, score))
         line += dt+ " , " + str(score) + "\n"      
       line += "\n"
       fo.write(line)
-  
+  with open("howie.json", "w") as jo:
+    json.dump(json_result, jo)
 
 def run(project_list, args, kernel_dir):
   for project in project_list:
     result_file = os.path.join(common.WORKING_DIR, args.dir, project+"_result.txt")
     kernel_file = os.path.join(common.WORKING_DIR, kernel_dir, project+"_kernel.txt")
+    print project_list
     check_similarity(project, result_file, kernel_file, args.cluster, min(5,len(project_list)))
 
     #compute_daikon_invariants(project_list, get_daikon_patterns())

--- a/frontend.py
+++ b/frontend.py
@@ -7,6 +7,7 @@ import pa2checker
 
 import backend
 import common
+import dot
 import argparse
 from simprog import Similarity
 
@@ -73,17 +74,14 @@ def compute_daikon_invariants(project_list, pattern_class_dir=None):
     shutil.rmtree(pattern_class_dir)
 
 
-
 def check_similarity(project, result_file, kernel_file, cluster_json=None, top_k=5):
   """ SUMMARY: use case of the user-driven functionality of PASCALI.
   """
-  dot_to_method_map = {}
   corpus_dot_to_method_map = {}
-  corpora = common.LIMITED_PROJECT_LIST
 
   # fetch various method information from each project in the list
-  output_dir = common.DOT_DIR[project]
-  method_file = common.get_method_path(project, output_dir)
+  output_dir = dot.dot_dirs(project)[0]
+  method_file = dot.get_method_path(project, output_dir)
 
   if not os.path.isfile(method_file):
     print ("Cannot find method file for project {0} at {1}".format(project, method_file))
@@ -96,7 +94,7 @@ def check_similarity(project, result_file, kernel_file, cluster_json=None, top_k
       items = line.split('\t')
       method_name = items[0]
       method_dot = items[1]
-      method_dot_path = common.get_dot_path(project, output_dir, method_dot)
+      method_dot_path = dot.get_dot_path(project, output_dir, method_dot)
       corpus_dot_to_method_map[method_dot_path] = method_name
 
   # check similarity
@@ -107,8 +105,8 @@ def check_similarity(project, result_file, kernel_file, cluster_json=None, top_k
     for dot_file in corpus_dot_to_method_map.keys():
       result_program_list_with_score = sim.find_top_k_similar_graphs(dot_file, dot_file, top_k, iter_num, cluster_json)
       line = dot_file+":\n"
-      for (dot, score) in result_program_list_with_score:
-        line += dot+ " , " + str(score) + "\n"      
+      for (dt, score) in result_program_list_with_score:
+        line += dt+ " , " + str(score) + "\n"      
       line += "\n"
       fo.write(line)
   

--- a/plot_hist.py
+++ b/plot_hist.py
@@ -4,7 +4,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 import os, sys, re
 from collections import defaultdict
 import argparse
-import common
+import common, dot
 from nltk.stem.porter import *
 
 """Read the program similarity result files and plot histograms"""
@@ -110,16 +110,16 @@ def plot_hist(x, xlabel, y, ylabel, fig_file, title=""):
 def get_dot_method_map(proj_lst):
 	dot_method_map = {}
 	for proj in proj_lst:
-            output_dir_lst = common.ALL_DOT_DIR[proj]
+            output_dir_lst = dot.dot_dirs(proj)
             for output_dir in output_dir_lst:
-                method_file = common.get_method_path(proj, output_dir)
+                method_file = dot.get_method_path(proj, output_dir)
                 with open(method_file, "r") as mf:
                     for line in mf:
                         line = line.rstrip()
                         items = line.split("\t")
                         method_name = items[0]
                         method_dot = items[1]
-                        method_dot_path = common.get_dot_path(proj, output_dir, method_dot)
+                        method_dot_path = dot.get_dot_path(proj, output_dir, method_dot)
                         dot_method_map[method_dot_path] = method_name
 	return dot_method_map
 

--- a/plot_scatter.py
+++ b/plot_scatter.py
@@ -4,7 +4,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 import os, sys, re
 from collections import defaultdict
 import argparse
-import common
+import common, dot
 from nltk.stem.snowball import *
 
 """Read the program similarity result files and plot text similarity vs. program similarity"""
@@ -89,16 +89,16 @@ def stem_word_lst(stemmer, word_lst):
 def get_dot_method_map(proj_lst):
     dot_method_map = {}
     for proj in proj_lst:
-        output_dir_lst = common.ALL_DOT_DIR[proj]
+        output_dir_lst = dot.dot_dirs(proj)
         for output_dir in output_dir_lst:
-            method_file = common.get_method_path(proj, output_dir)
+            method_file = dot.get_method_path(proj, output_dir)
             with open(method_file, "r") as mf:
                 for line in mf:
                     line = line.rstrip()
                     items = line.split("\t")
                     method_name = items[0]
                     method_dot = items[1]
-                    method_dot_path = common.get_dot_path(proj, output_dir, method_dot)
+                    method_dot_path = dot.get_dot_path(proj, output_dir, method_dot)
                     dot_method_map[method_dot_path] = method_name
     return dot_method_map
 

--- a/run_restricted.sh
+++ b/run_restricted.sh
@@ -3,4 +3,4 @@
 #"dyn4j", "jreactphysics3d", "jbox2d", "react", "jmonkeyengine"
 
 echo "Run for the jreact and react only"
-python experiment.py -g -rc -d mini -p "jreactphysics3d,react"
+python experiment.py -g -rc -d restricted -p "jreactphysics3d,react"

--- a/run_short_image.sh
+++ b/run_short_image.sh
@@ -4,4 +4,4 @@
 
 echo "Run for boofcv,imagej,thumbnailinator,imglib2,imgscalr,catalano"
 #python experiment.py -g -rc -d mini -p "imagej,imglib2"
-python experiment.py -g -rc -d mini -p "imgscalr"
+python experiment.py -g -rc -d shortimg -p "imgscalr,imagej"


### PR DESCRIPTION
The hardcoded dot paths have been removed and replaced (as well as moving some stuff from common.py, which was getting quite bloated) with a new module, `dot`, that handles looking up dot-related stuff.

After making these changes, run_mini runs to completion, but I'm not entirely confident that everything is correct, so don't merge without verifying.

The biggest issue I can see is that in the old code, `DOT_DIR[project]` returned a single directory name, whereas `dot.dot_dirs(project)` returns a list of directories. For now, I've set it so that places that used the old `DOT_DIR[project]` lookup only look at the first item of `dot.dot_dirs`, but that will probably lead to missing a lot of stuff. Those methods probably need to be rewritten to search multiple dot dirs, but I'm not sure if I understand what's going on in the graph similarity stuff to do the rewriting myself.