### PR TITLE
[common.py#run_cmd()] propagate the stderr output of the running command

### DIFF
--- a/common.py
+++ b/common.py
@@ -63,6 +63,12 @@ def run_cmd(cmd, print_output=False, timeout=None):
         sys.stdout.write(line)
         sys.stdout.flush()
     process.stdout.close()
+    for line in iter(process.stderr.readline, b''):
+      if print_output:
+        sys.stderr.write(line)
+        sys.stderr.flush()
+    process.stderr.close()
+
     process.wait()
     stats['return_code'] = process.returncode
     if timer:

--- a/common.py
+++ b/common.py
@@ -63,7 +63,6 @@ def run_cmd(cmd, print_output=False, timeout=None):
         sys.stdout.write(line)
         sys.stdout.flush()
     process.stdout.close()
-
     process.wait()
     stats['return_code'] = process.returncode
     if timer:

--- a/common.py
+++ b/common.py
@@ -51,7 +51,7 @@ def run_cmd(cmd, print_output=False, timeout=None):
   if print_output:
     print ("Running %s" % ' '.join(cmd))
   try:
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     if timeout:
       timer = Timer(timeout, kill_proc, [process, stats])
@@ -63,11 +63,6 @@ def run_cmd(cmd, print_output=False, timeout=None):
         sys.stdout.write(line)
         sys.stdout.flush()
     process.stdout.close()
-    for line in iter(process.stderr.readline, b''):
-      if print_output:
-        sys.stderr.write(line)
-        sys.stderr.flush()
-    process.stderr.close()
 
     process.wait()
     stats['return_code'] = process.returncode


### PR DESCRIPTION
add a for-loop in `common.py#run_cmd()` to print out the `stderr` content if the parameter `print_output` was set to `True`.

This would benefit the debugging process during developing scripts as we could see the stderr output if some errors happened during executing a command.