### PR TITLE
Solved multiple declarations failed compilation issue in map2annotation

### DIFF
--- a/map2annotation/fetch_map2anno_tools.sh
+++ b/map2annotation/fetch_map2anno_tools.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+MAP2ANNO_DIR=$(cd $(dirname "$0") && pwd)
+
+##### build hacked checkstyle
+if [ ! -d $MAP2ANNO_DIR/checkstyle ] ; then
+    # rm -rf $MAP2ANNO_DIR/checkstyle
+    (cd $MAP2ANNO_DIR && git clone --depth 1 --branch multiDeclJson https://github.com/CharlesZ-Chen/checkstyle.git)
+    (cd $MAP2ANNO_DIR/checkstyle && mvn clean package -Passembly)
+fi
+(cd $MAP2ANNO_DIR/checkstyle && git pull)
+
+##### fetch refactor front-end
+if [ ! -d $MAP2ANNO_DIR/multiDeclRefactor ] ; then
+    # rm -rf $MAP2ANNO_DIR/multiDeclRefactor
+    (cd $MAP2ANNO_DIR && git clone --depth 1 https://github.com/CharlesZ-Chen/multiDeclRefactor.git)
+fi
+(cd $MAP2ANNO_DIR/multiDeclRefactor && git pull)

--- a/map2annotation/map2annotation.py
+++ b/map2annotation/map2annotation.py
@@ -28,11 +28,24 @@ def field_mappings_to_annotation(json_file):
 
     corpus_jaif_file = create_corpus_jaif(mappings)
 
-    # for project in project_list:
-    #     insert_anno_to_project(project, corpus_jaif_file)
+    for project in project_list:
+        refactor_multi_decl(project)
 
-    # for project in project_list:
-    #     frontend_pa_inference.run_inference(project)
+    for project in project_list:
+        insert_anno_to_project(project, corpus_jaif_file)
+
+    for project in project_list:
+        frontend_pa_inference.run_inference(project)
+
+def refactor_multi_decl(project):
+    project_dir = common.get_project_dir(project)
+    refactor_script = os.path.join(MAP_WORKING_DIR, "multiDeclRefactor", "run-refactor.sh")
+    refactor_cmd = [refactor_script, project_dir]
+    common.run_cmd(refactor_cmd)
+
+def init_multi_decl_refactor():
+    FETCH_TOOL_SCRIPT = os.path.join(MAP_WORKING_DIR, "fetch_map2anno_tools.sh")
+    common.run_cmd(FETCH_TOOL_SCRIPT)
 
 def type_mappings_to_rules(json_file):
     with open(json_file) as data_file:


### PR DESCRIPTION
A workaround to solved the `annotation-tool` [simultaneous declarations issue](https://github.com/typetools/annotation-tools/issues/36), which would cause `annotation-tool` insert mal-grammer annotations if source code contains simultaneous declarations.

- add a refactor step to refactor multiple declarations in project source code

- re-active insert annotation part

- re-active propagation inference part

I've tested this updated `map2annotation` script in my local machine, and since now inference part is active, it takes quite a long time to finish (around 2 hours in my machine).
