### PR TITLE
fix bug: fix map2annotation always run inference on all projects in corpus 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ corpus/annotated/
 corpus/**/logs/
 **/*.jaif
 **/__java_file_names.txt
+word_based_field_clusters.json
 
 # Pycharm
 .idea/*
@@ -34,3 +35,7 @@ clusters.json
 kernel_directory/
 mini/
 results/
+
+# map2annotation
+map2annotation/checkstyle/
+map2annotation/multiDeclRefactor/

--- a/backend.py
+++ b/backend.py
@@ -93,7 +93,9 @@ def compute_clusters_for_classes(project_list, out_file_name, cf_map_file_name="
 
   if wf_map_file_name:
     print ("Generate jaif file")
-    map2annotation.field_mappings_to_annotation(wf_map_file_name)
+    map2annotation.field_mappings_to_annotation(project_list, wf_map_file_name)
+    for project in project_list:
+        map2annotation.run_anno_inference(project)
 
 def run(project_list, args, kernel_dir):
   if os.path.isfile(common.CLUSTER_FILE) and not args.recompute_clusters:

--- a/map2annotation/__init__.py
+++ b/map2annotation/__init__.py
@@ -6,3 +6,4 @@ insert_anno_to_project = map2annotation.insert_anno_to_project
 create_corpus_jaif = map2annotation.create_corpus_jaif
 create_jaif_file = map2annotation.create_jaif_file
 convert_2_ontology_value = map2annotation.convert_2_ontology_value
+run_anno_inference = map2annotation.run_anno_inference


### PR DESCRIPTION
fixed the bug of `map2annotation` always run  inference on all projects in corpus.

Updated `backend.py` adapt to this fix. 