### PR TITLE
Update to latest version of Daikon tool set.

### DIFF
--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -49,7 +49,7 @@ if [ -d do-like-javac ]; then
 fi
 git clone https://github.com/SRI-CSL/do-like-javac.git
 
-DAIKON_SRC="http://plse.cs.washington.edu/daikon/download/daikon-5.4.6.tar.gz"
+DAIKON_SRC="http://plse.cs.washington.edu/daikon/download/daikon-5.5.0.tar.gz"
 
 if [ ! -d daikon-src ]; then
   if curl -fLo daikon-src.tgz $DAIKON_SRC; then


### PR DESCRIPTION
IMPORTANT: this pull request relies on a change in do-like-javac.  
https://github.com/SRI-CSL/do-like-javac/pull/13 must be processed in parallel with this pull request.
