### PR TITLE
Update Randoop dependency to 3.0.10

### DIFF
--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -11,7 +11,7 @@ mkdir -p libs
 pushd libs &> /dev/null
 
 JARS=(
-    "https://github.com/randoop/randoop/releases/download/v3.0.8/randoop-all-3.0.8.jar"
+    "https://github.com/randoop/randoop/releases/download/v3.0.10/randoop-all-3.0.10.jar"
     "https://github.com/aas-integration/prog2dfg/releases/download/v0.1/prog2dfg.jar"
     "https://github.com/junit-team/junit/releases/download/r4.12/junit-4.12.jar"
     "http://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"


### PR DESCRIPTION
This just updates fetch_dependencies to use Randoop v3.0.10, which is more robust to failures of type selection heuristics.