### PR TITLE
Update randoop to version 3.1.5

### DIFF
--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -11,7 +11,7 @@ mkdir -p libs
 pushd libs &> /dev/null
 
 JARS=(
-    "https://github.com/randoop/randoop/releases/download/v3.1.4/randoop-all-3.1.4.jar"
+    "https://github.com/randoop/randoop/releases/download/v3.1.5/randoop-all-3.1.5.jar"
     "https://github.com/aas-integration/prog2dfg/releases/download/v0.1/prog2dfg.jar"
     "https://github.com/junit-team/junit/releases/download/r4.12/junit-4.12.jar"
     "http://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"


### PR DESCRIPTION
This update fixes a bug that occurs when running over the ejml library in the corpus.